### PR TITLE
Update to XHTML (for valid EPUB 2)

### DIFF
--- a/lib/content.ejs
+++ b/lib/content.ejs
@@ -13,12 +13,12 @@
     </opf:metadata>
     <opf:manifest>
         <opf:item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-        <opf:item id="contents" href="contents.html" media-type="text/html" />
+        <opf:item id="contents" href="contents.xhtml" media-type="application/xhtml+xml" />
         <opf:item id="image_cover" href="cover.jpg" media-type="image/jpeg" />
         <% images.forEach(function(image, index){ %>
         <opf:item id="image_<%= index %>" href="images/<%= image.id %>.jpg" media-type="image/jpeg" /><% }) %>
         <% content.forEach(function(content){ %>
-        <opf:item id="<%= content.id %>" href="<%= content.href %>" media-type="text/html" /><% }) %>
+        <opf:item id="<%= content.id %>" href="<%= content.href %>" media-type="application/xhtml+xml" /><% }) %>
         <opf:item id="style-css" href="style.css" media-type="text/css" />
         <% fonts.forEach(function(font) { %>
         <opf:item id="<%= font %>" href="fonts/<%= font %>" media-type="application/x-font-ttf" /><% }) %>

--- a/lib/content.xhtml
+++ b/lib/content.xhtml
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html lang="<%- lang %>">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="<%- lang %>">
 <head>
     <title><%= title %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -124,8 +124,8 @@ class EPub
     fs.mkdirSync(path.resolve @uuid, "./OEBPS/images")
     _.each @options.content, (content)->
       data = """
-      <!DOCTYPE html>
-      <html lang="#{self.options.lang}">
+      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+      <html xmlns="http://www.w3.org/1999/xhtml" lang="#{self.options.lang}">
         <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title>#{content.title}</title>

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -146,6 +146,16 @@ class EPub
     fs.mkdirSync(@uuid + "/META-INF")
     fs.writeFileSync( "#{@uuid}/META-INF/container.xml", """<?xml version="1.0" encoding="UTF-8" ?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles></container>""")
 
+    # write meta-inf/com.apple.ibooks.display-options.xml
+    fs.writeFileSync( "#{@uuid}/META-INF/com.apple.ibooks.display-options.xml","""
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <display_options>
+        <platform name="*">
+          <option name="specified-fonts">true</option>
+        </platform>
+      </display_options>
+    """)
+
     opfPath = self.options.customOpfTemplatePath or path.resolve(__dirname, "./content.ejs")
     if !fs.existsSync(opfPath)
       generateDefer.reject(new Error('Custom file to OPF template not found.'))

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -58,8 +58,8 @@ class EPub
     @options.images = []
     @options.content = _.map @options.content, (content, index)->
       titleSlug = uslug removeDiacritics content.title || "no title"
-      content.filePath = path.resolve self.uuid, "./OEBPS/#{index}_#{titleSlug}.html"
-      content.href = "#{index}_#{titleSlug}.html"
+      content.filePath = path.resolve self.uuid, "./OEBPS/#{index}_#{titleSlug}.xhtml"
+      content.href = "#{index}_#{titleSlug}.xhtml"
       content.id = "item_#{index}"
 
       #fix Author Array
@@ -156,7 +156,7 @@ class EPub
       generateDefer.reject(new Error('Custom file the NCX toc template not found.'))
       return generateDefer.promise
 
-    htmlTocPath = self.options.customHtmlTocTemplatePath or path.resolve(__dirname, "./content.html")
+    htmlTocPath = self.options.customHtmlTocTemplatePath or path.resolve(__dirname, "./content.xhtml")
     if !fs.existsSync(htmlTocPath)
       generateDefer.reject(new Error('Custom file to HTML toc template not found.'))
       return generateDefer.promise
@@ -168,7 +168,7 @@ class EPub
     ]).spread (data1, data2, data3)->
       fs.writeFileSync(path.resolve(self.uuid , "./OEBPS/content.opf"), data1)
       fs.writeFileSync(path.resolve(self.uuid , "./OEBPS/toc.ncx"), data2)
-      fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/contents.html"), data3)
+      fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/contents.xhtml"), data3)
       generateDefer.resolve()
     , (err)->
       console.error arguments

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,8 +79,8 @@
       this.options.content = _.map(this.options.content, function(content, index) {
         var $, titleSlug;
         titleSlug = uslug(removeDiacritics(content.title || "no title"));
-        content.filePath = path.resolve(self.uuid, "./OEBPS/" + index + "_" + titleSlug + ".html");
-        content.href = index + "_" + titleSlug + ".html";
+        content.filePath = path.resolve(self.uuid, "./OEBPS/" + index + "_" + titleSlug + ".xhtml");
+        content.href = index + "_" + titleSlug + ".xhtml";
         content.id = "item_" + index;
         content.author = content.author && _.isString(content.author) ? [content.author] : !content.author || !_.isArray(content.author) ? [] : content.author;
         $ = cheerio.load(content.data, {
@@ -176,7 +176,7 @@
         generateDefer.reject(new Error('Custom file the NCX toc template not found.'));
         return generateDefer.promise;
       }
-      htmlTocPath = self.options.customHtmlTocTemplatePath || path.resolve(__dirname, "./content.html");
+      htmlTocPath = self.options.customHtmlTocTemplatePath || path.resolve(__dirname, "./content.xhtml");
       if (!fs.existsSync(htmlTocPath)) {
         generateDefer.reject(new Error('Custom file to HTML toc template not found.'));
         return generateDefer.promise;
@@ -184,7 +184,7 @@
       Q.all([Q.nfcall(ejs.renderFile, opfPath, self.options), Q.nfcall(ejs.renderFile, ncxTocPath, self.options), Q.nfcall(ejs.renderFile, htmlTocPath, self.options)]).spread(function(data1, data2, data3) {
         fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/content.opf"), data1);
         fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/toc.ncx"), data2);
-        fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/contents.html"), data3);
+        fs.writeFileSync(path.resolve(self.uuid, "./OEBPS/contents.xhtml"), data3);
         return generateDefer.resolve();
       }, function(err) {
         console.error(arguments);

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,6 +166,7 @@
       fs.writeFileSync(this.uuid + "/mimetype", "application/epub+zip");
       fs.mkdirSync(this.uuid + "/META-INF");
       fs.writeFileSync(this.uuid + "/META-INF/container.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles></container>");
+      fs.writeFileSync(this.uuid + "/META-INF/com.apple.ibooks.display-options.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<display_options>\n  <platform name=\"*\">\n    <option name=\"specified-fonts\">true</option>\n  </platform>\n</display_options>");
       opfPath = self.options.customOpfTemplatePath || path.resolve(__dirname, "./content.ejs");
       if (!fs.existsSync(opfPath)) {
         generateDefer.reject(new Error('Custom file to OPF template not found.'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@
       fs.mkdirSync(path.resolve(this.uuid, "./OEBPS/images"));
       _.each(this.options.content, function(content) {
         var data;
-        data = "<!DOCTYPE html>\n<html lang=\"" + self.options.lang + "\">\n  <head>\n  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n  <title>" + content.title + "</title>\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\" />\n  </head>\n<body>";
+        data = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"" + self.options.lang + "\">\n  <head>\n  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n  <title>" + content.title + "</title>\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\" />\n  </head>\n<body>";
         data += content.title && self.options.appendChapterTitles ? "<h1>" + content.title + "</h1>" : "";
         data += content.title && content.author && content.author.length ? "<p class='epub-author'>" + (content.author.join(", ")) + "</p>" : "";
         data += content.title && content.url ? "<p class='epub-link'><a href='" + content.url + "'>" + content.url + "</a></p>" : "";

--- a/lib/toc.ejs
+++ b/lib/toc.ejs
@@ -18,7 +18,7 @@
             <navLabel>
                 <text><%= tocTitle %></text>
             </navLabel>
-            <content src="contents.html"/>
+            <content src="contents.xhtml"/>
         </navPoint>
         <% content.forEach(function(content, index){ %>
         <navPoint id="navPoint-<%= +index+1 %>" playOrder="<%= +index+1 %>" class="chapter">


### PR DESCRIPTION
Updates the format of the generated EPUB content document from HTML to XHTML, to maintain compatibility with EPUB 2 as per [OPS standard](http://www.idpf.org/epub/20/spec/OPS_2.0.1_draft.htm#Section1.4.1) and [OPF standard](http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4).

Also includes a `com.apple.ibooks.display-options.xml` file needed for iBooks to display custom fonts properly.