### PR TITLE
Removed metadata pollution

### DIFF
--- a/lib/content.ejs
+++ b/lib/content.ejs
@@ -4,12 +4,12 @@
         <dc:identifier id="BookId" opf:scheme="URN">uuid:<%= id %></dc:identifier>
         <dc:title><%= title %></dc:title>
         <dc:description><%= description %></dc:description>
-        <dc:publisher><%= publisher || "cyrilis.com" %></dc:publisher>
+        <dc:publisher><%= publisher || "anonymous" %></dc:publisher>
         <dc:creator opf:role="aut" opf:file-as="<%= author.length ? author.join(",") : author %>"><%= author.length ? author.join(",") : author %></dc:creator>
         <dc:date opf:event="modification"><%= date %></dc:date>
         <dc:language><%= lang || "en" %></dc:language>
         <opf:meta name="cover" content="image_cover" />
-        <opf:meta name="generator" content="TxT.SX" />
+        <opf:meta name="generator" content="epub-gen" />
     </opf:metadata>
     <opf:manifest>
         <opf:item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -35,7 +35,7 @@ class EPub
 
     @options = _.extend {
       description: options.title
-      publisher: "TXT.SX"
+      publisher: "anonymous"
       author: ["anonymous"]
       tocTitle: "Table Of Content"
       appendChapterTitles: true

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -271,8 +271,8 @@ class EPub
 
     self = @
     filename = "book.epub.zip"
-    initCmd = "zip -X -0 #{filename} mimetype"
-    zipCmd  = "zip -X -9 -r #{filename} * -x mimetype #{filename}"
+    initCmd = "zip -q -X -0 #{filename} mimetype"
+    zipCmd  = "zip -q -X -9 -r #{filename} * -x mimetype #{filename}"
     cleanUp = "mv #{filename} book.epub && rm -f -r META-INF OEBPS mimetype"
     cleanUp = "mv #{filename} book.epub"
     cwd = @uuid

--- a/lib/index.js
+++ b/lib/index.js
@@ -300,8 +300,8 @@
       genDefer = new Q.defer();
       self = this;
       filename = "book.epub.zip";
-      initCmd = "zip -X -0 " + filename + " mimetype";
-      zipCmd = "zip -X -9 -r " + filename + " * -x mimetype " + filename;
+      initCmd = "zip -q -X -0 " + filename + " mimetype";
+      zipCmd = "zip -q -X -9 -r " + filename + " * -x mimetype " + filename;
       cleanUp = "mv " + filename + " book.epub && rm -f -r META-INF OEBPS mimetype";
       cleanUp = "mv " + filename + " book.epub";
       cwd = this.uuid;

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@
       }
       this.options = _.extend({
         description: options.title,
-        publisher: "TXT.SX",
+        publisher: "anonymous",
         author: ["anonymous"],
         tocTitle: "Table Of Content",
         appendChapterTitles: true,

--- a/lib/toc.ejs
+++ b/lib/toc.ejs
@@ -2,7 +2,7 @@
 <ncx version="2005-1" xmlns="http://www.daisy.org/z3986/2005/ncx/">
     <head>
         <meta name="dtb:uid" content="urn:uuid:<%= uuid %>" />
-        <meta name="dtb:generator" content="TxT.SX"/>
+        <meta name="dtb:generator" content="epub-gen"/>
         <meta name="dtb:depth" content="1"/>
         <meta name="dtb:totalPageCount" content="0"/>
         <meta name="dtb:maxPageNumber" content="0"/>


### PR DESCRIPTION
The publisher & generator fields were being polluted, this changes publisher to 'anonymous' and generator to 'epub-gen' instead of the default values.

Hopefully fixes #7.