### PR TITLE
Use raw data (rather than entities parsed version); required for new line preservation

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -209,7 +209,7 @@ class EPub
       data += if content.title and self.options.appendChapterTitles then "<h1>#{entities.encodeXML(content.title)}</h1>" else ""
       data += if content.title and content.author and content.author.length then "<p class='epub-author'>#{entities.encodeXML(content.author.join(", "))}</p>" else ""
       data += if content.title and content.url then "<p class='epub-link'><a href='#{content.url}'>#{content.url}</a></p>" else ""
-      data += "#{content.data}</body></html>"
+      data += "#{content.rawData || content.data}</body></html>"
       fs.writeFileSync(content.filePath, data)
 
     # write mimetype file

--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@
         data += content.title && self.options.appendChapterTitles ? "<h1>" + (entities.encodeXML(content.title)) + "</h1>" : "";
         data += content.title && content.author && content.author.length ? "<p class='epub-author'>" + (entities.encodeXML(content.author.join(", "))) + "</p>" : "";
         data += content.title && content.url ? "<p class='epub-link'><a href='" + content.url + "'>" + content.url + "</a></p>" : "";
-        data += content.data + "</body></html>";
+        data += (content.rawData || content.data) + "</body></html>";
         return fs.writeFileSync(content.filePath, data);
       });
       fs.writeFileSync(this.uuid + "/mimetype", "application/epub+zip");


### PR DESCRIPTION
I was processing some content which had code samples. Unfortunately the newlines were lost in the entities process.

This is simplest way I could think of solving this (can pass in an optional rawData along with data to preserve the raw string (with newlines). If nothing is supplied will just use `content.data` as before.