### PR TITLE
Define `epub` namespace in EPUB v3 `docHeader`.

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -62,7 +62,7 @@ class EPub
     else
       @options.docHeader = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="#{self.options.lang}">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="#{self.options.lang}">
 """
 
     if _.isString @options.author

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@
       if (this.options.version === 2) {
         this.options.docHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"" + self.options.lang + "\">";
       } else {
-        this.options.docHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"" + self.options.lang + "\">";
+        this.options.docHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\" lang=\"" + self.options.lang + "\">";
       }
       if (_.isString(this.options.author)) {
         this.options.author = [this.options.author];


### PR DESCRIPTION
Undefined `epub` namespace will cause render error when the namespace is used (e.g., footnotes).

I think you should make this part configurable, or use templates for generating content xhtml files. 