### PR TITLE
Revert "Added option to include XHTML 1.1 DTD in DOCTYPE even when ePub versi…"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ Then put this in your code:
     Optional. For advanced customizations: absolute path to a NCX toc template.
 - `customHtmlTocTemplatePath`:
     Optional. For advanced customizations: absolute path to a HTML toc template.
-- `includeDTDEvenInVersion3`:
-		Optional. Include XHTML 1.1 DTD in DOCTYPE even when the ePub version is 3. 
 - `content`:
     Book Chapters content. It's should be an array of objects. eg. `[{title: "Chapter 1",data: "<div>..."}, {data: ""},...]`
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -51,11 +51,10 @@ class EPub
       customOpfTemplatePath: null
       customNcxTocTemplatePath: null
       customHtmlTocTemplatePath: null
-      includeDTDEvenInVersion3: true
       version: 3
     }, options
 
-    if @options.version is 2 or (@options.version is 3 and @options.includeDTDEvenInVersion3 is true)
+    if @options.version is 2
       @options.docHeader = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="#{self.options.lang}">

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,10 +70,9 @@
         customOpfTemplatePath: null,
         customNcxTocTemplatePath: null,
         customHtmlTocTemplatePath: null,
-        includeDTDEvenInVersion3: false,
         version: 3
       }, options);
-      if (this.options.version === 2 || (this.options.version === 3 && this.options.includeDTDEvenInVersion3)) {
+      if (this.options.version === 2) {
         this.options.docHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"" + self.options.lang + "\">";
       } else {
         this.options.docHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\" lang=\"" + self.options.lang + "\">";


### PR DESCRIPTION
Reverts cyrilis/epub-gen#40.

On EPUB 3 standard content documents are based on HTML5 XML which doesn't support DTDs and also doesn't support named entities - apart from a very small set. I see no reason why this library should allow to produce invalid EPUBs, hence I'm reverting this.