### PR TITLE
Remove query from img src URLs for MIME

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -142,7 +142,7 @@ class EPub
           extension = image.extension
         else
           id = uuid()
-          mediaType = mime.lookup url
+          mediaType = mime.lookup url.replace /\?.*/, ""
           extension = mime.extension mediaType
           dir = content.dir
           self.options.images.push {id, url, dir, mediaType, extension}

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,7 +166,7 @@
             extension = image.extension;
           } else {
             id = uuid();
-            mediaType = mime.lookup(url);
+            mediaType = mime.lookup(url.replace(/\?.*/, ""));
             extension = mime.extension(mediaType);
             dir = content.dir;
             self.options.images.push({id, url, dir, mediaType, extension});


### PR DESCRIPTION
Fixes the issue raised by @alecgibson on #53: images with URLs/src's with query strings make the MIME type lookup to incorrectly return `"application/octet-stream"` as the type.

This PR adds query string removal on image URLs for MIME type lookup purposes.