### PR TITLE
Add JS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Then put this in your code:
     You can specify the version of the generated EPUB, `3` the latest version (http://idpf.org/epub/30) or `2` the previous version (http://idpf.org/epub/201, for better compatibility with older readers). If not specified, will fallback to `3`.
 - `css`:
     If you really hate our css, you can pass css string to replace our default style. eg: `"body{background: #000}"`
+-`js`:
+    This property can be used to supply custom Javascript code as a string. eg: `console.log('I support JS!')`
 - `fonts`:
     Array of (absolute) paths to custom fonts to include on the book so they can be used on custom css. Ex: if you configure the array to `fonts: ['/path/to/Merriweather.ttf']` you can use the following on the custom CSS:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,8 +221,12 @@
       }
       fs.mkdirSync(this.uuid);
       fs.mkdirSync(path.resolve(this.uuid, "./OEBPS"));
+      // Apply custom css of load the default css rules
       (base = this.options).css || (base.css = fs.readFileSync(path.resolve(__dirname, "../templates/template.css")));
       fs.writeFileSync(path.resolve(this.uuid, "./OEBPS/style.css"), this.options.css);
+      // Apply custom scripts or load default js scripts
+      (base = this.options).js || (base.js = fs.readFileSync(path.resolve(__dirname, "../templates/default-scripts.js")));
+      fs.writeFileSync(path.resolve(this.uuid, "./OEBPS/scripts.js"), this.options.js);
       if (self.options.fonts.length) {
         fs.mkdirSync(path.resolve(this.uuid, "./OEBPS/fonts"));
         this.options.fonts = _.map(this.options.fonts, function(font) {
@@ -238,7 +242,7 @@
       }
       _.each(this.options.content, function(content) {
         var data;
-        data = `${self.options.docHeader}\n  <head>\n  <meta charset="UTF-8" />\n  <title>${entities.encodeXML(content.title || '')}</title>\n  <link rel="stylesheet" type="text/css" href="style.css" />\n  </head>\n<body>`;
+        data = `${self.options.docHeader}\n  <head>\n  <meta charset="UTF-8" />\n  <title>${entities.encodeXML(content.title || '')}</title>\n  <link rel="stylesheet" type="text/css" href="style.css" />\n <script src="scripts.js"></script>\n  </head>\n<body>`;
         data += content.title && self.options.appendChapterTitles ? `<h1>${entities.encodeXML(content.title)}</h1>` : "";
         data += content.title && content.author && content.author.length ? `<p class='epub-author'>${entities.encodeXML(content.author.join(", "))}</p>` : "";
         data += content.title && content.url ? `<p class='epub-link'><a href='${content.url}'>${content.url}</a></p>` : "";

--- a/templates/default-scripts.js
+++ b/templates/default-scripts.js
@@ -1,0 +1,1 @@
+console.log( 'This EPUB supports Javascript' )

--- a/templates/epub3/content.opf.ejs
+++ b/templates/epub3/content.opf.ejs
@@ -38,6 +38,8 @@
         <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
         <item id="toc" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
         <item id="css" href="style.css" media-type="text/css" />
+        <item id="scripts" href="scripts.js" media-type="text/javascript"/>
+
 
         <% if(locals.cover) { %>
         <item id="image_cover" href="cover.<%= _coverExtension %>" media-type="<%= _coverMediaType %>" />


### PR DESCRIPTION
Based on our conversation [here](https://github.com/cyrilis/epub-gen/issues/48_) this is a PR that (if I understood your code flow correctly) should integrate well with your current code.

The new lines will load a default script (with a console.log stating js support) or apply custom js as applied in the options.js property.