### PR TITLE
Add: timeout and retry for image download.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,8 @@
 
   request = require("superagent");
 
+  (require("superagent-retry"))(request);
+
   fsextra = require("fs-extra");
 
   removeDiacritics = require("diacritics").remove;
@@ -85,7 +87,7 @@
         this.options.author = ["anonymous"];
       }
       if (!this.options.tempDir) {
-        this.options.tempDir = path.resolve(__dirname, "../tempDir/");
+        this.options.tempDir = path.resolve("./tempDir/");
       }
       this.id = uuid();
       this.uuid = path.resolve(this.options.tempDir, this.id);
@@ -299,7 +301,10 @@
         destPath = path.resolve(this.uuid, "./OEBPS/cover." + this.options._coverExtension);
         writeStream = null;
         if (this.options.cover.slice(0, 4) === "http") {
-          writeStream = request.get(this.options.cover).set({
+          writeStream = request.get(this.options.cover).timeout({
+            response: 10e3, //Wait 10 seconds for the server to start sending
+            deadline: 3 * 60e3 //allow 3 minute for the image to finish loading
+          }).retry(2).set({ // retry 2 times before responding
             'User-Agent': userAgent
           });
           writeStream.pipe(fs.createWriteStream(destPath));
@@ -336,7 +341,10 @@
         return downloadImageDefer.resolve(options);
       } else {
         if (options.url.indexOf("http") === 0) {
-          requestAction = request.get(options.url).set({
+          requestAction = request.get(options.url).timeout({
+            response: 10000, //Wait 10 seconds for the server to start sending
+            deadline: 3 * 60e3 //allow 3 minute for the image to finish loading
+          }).retry(2).set({ // retry 2 times before responding
             'User-Agent': userAgent
           });
           requestAction.pipe(fs.createWriteStream(filename));
@@ -423,3 +431,5 @@
   module.exports = EPub;
 
 }).call(this);
+
+//# sourceMappingURL=index.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -658,6 +658,11 @@
         }
       }
     },
+    "superagent-retry": {
+      "version": "0.6.0",
+      "resolved": "http://registry.npm.taobao.org/superagent-retry/download/superagent-retry-0.6.0.tgz",
+      "integrity": "sha1-5Js1ypbA47HQ4/SWBRNt8OCgKLc="
+    },
     "tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "q": "^1.5.1",
     "rimraf": "^2.6.3",
     "superagent": "^3.8.3",
+    "superagent-retry": "^0.6.0",
     "underscore": "^1.9.1",
     "uslug": "^1.0.4"
   },


### PR DESCRIPTION
Signed-off-by: gonejack <igonejack@gmail.com>

Hi, @cyrilis 

I add some default timeout and retry for image downloads for epub-gen, just SuperAgent's built in feature.

About the tempDir, just to avoid epub-gen create files under people's node_modules, I think it's a mistake so change it.

![image](https://user-images.githubusercontent.com/2720676/54071503-3608dc00-42a8-11e9-8926-f6cda61c4fbb.png)

New to coffee script but do run the test.