### PR TITLE
Table of Contents Change

### DIFF
--- a/templates/epub3/toc.xhtml.ejs
+++ b/templates/epub3/toc.xhtml.ejs
@@ -17,9 +17,6 @@
                 </li>
             <% } %>
         <% }) %>
-        <li class="table-of-content">
-            <a href="toc.xhtml">- <%= tocTitle %> -</a>
-        </li>
         <% content.forEach(function(content, index){ %>
             <% if(!content.excludeFromToc && !content.beforeToc){ %>
                 <li class="table-of-content">


### PR DESCRIPTION
Remove unnecessary first tocTitle `<li>` from the TOC

Fixes #46 