### PR TITLE
Fix default test

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ If you don't want pass the output pass the output path as the second argument, y
 
 _From Lewis Carroll "Alice's Adventures in Wonderland", based on text at https://www.cs.cmu.edu/~rgs/alice-table.html and images from http://www.alice-in-wonderland.net/resources/pictures/alices-adventures-in-wonderland._
 
+## Tests
+
+Run `npm run test` 
+
+If it succeeds, you'll see:
+```
+Alice's Adventures in Wonderland is generated successfully
+```
+
+If it fails, you'll see:
+```
+
+```
+
+Want to improve this library's testing library? Please contribute! https://github.com/cyrilis/epub-gen/issues/57
+
 ## License
 
 (The MIT License)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Alice's Adventures in Wonderland is generated successfully
 
 If it fails, you'll see:
 ```
-
+failed to generate epub
 ```
 
 Want to improve this library's testing library? Please contribute! https://github.com/cyrilis/epub-gen/issues/57

--- a/test.coffee
+++ b/test.coffee
@@ -24,4 +24,6 @@ optionsAlice = {
 }
 
 new EPub(optionsAlice, path.resolve(__dirname, "./tempDir/book.epub")).promise.then ()->
-  console.log "#{options.title} is generated successfully"
+  console.log "#{optionsAlice.title} is generated successfully"
+.catch (e)->
+  console.error "failed to generate epub", e

--- a/test.js
+++ b/test.js
@@ -29,7 +29,9 @@
   };
 
   new EPub(optionsAlice, path.resolve(__dirname, "./tempDir/book.epub")).promise.then(function() {
-    return console.log(`${options.title} is generated successfully`);
+    return console.log(`${optionsAlice.title} is generated successfully`);
+  }).catch(function(e) {
+    return console.error("failed to generate epub", e);
   });
 
 }).call(this);


### PR DESCRIPTION
Running `npm run test` does nothing.

This is because it actually was failing silently.

The `console.log #{options.title}` line fails. This is because `options` should be `aliceOptions`. 

This PR fixes the test and also adds a very basic reference to this script in the README. 