### PR TITLE
Fix crashing epub generation when image has no src

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -138,16 +138,17 @@ class EPub
 
       $("img").each (index, elem)->
         url = $(elem).attr("src")
-        if image = self.options.images.find((element) -> element.url == url)
-          id = image.id
-          extension = image.extension
-        else
-          id = uuid()
-          mediaType = mime.getType url.replace /\?.*/, ""
-          extension = mime.getExtension mediaType
-          dir = content.dir
-          self.options.images.push {id, url, dir, mediaType, extension}
-        $(elem).attr("src", "images/#{id}.#{extension}")
+        if url
+          if image = self.options.images.find((element) -> element.url == url)
+            id = image.id
+            extension = image.extension
+          else
+            id = uuid()
+            mediaType = mime.getType url.replace /\?.*/, ""
+            extension = mime.getExtension mediaType
+            dir = content.dir
+            self.options.images.push {id, url, dir, mediaType, extension}
+          $(elem).attr("src", "images/#{id}.#{extension}")
       content.data = $.xml()
       content
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,19 +163,21 @@
         $("img").each(function(index, elem) {
           var dir, extension, id, image, mediaType, url;
           url = $(elem).attr("src");
-          if (image = self.options.images.find(function(element) {
-            return element.url === url;
-          })) {
-            id = image.id;
-            extension = image.extension;
-          } else {
-            id = uuid();
-            mediaType = mime.getType(url.replace(/\?.*/, ""));
-            extension = mime.getExtension(mediaType);
-            dir = content.dir;
-            self.options.images.push({id, url, dir, mediaType, extension});
+          if (url) {
+            if (image = self.options.images.find(function(element) {
+              return element.url === url;
+            })) {
+              id = image.id;
+              extension = image.extension;
+            } else {
+              id = uuid();
+              mediaType = mime.getType(url.replace(/\?.*/, ""));
+              extension = mime.getExtension(mediaType);
+              dir = content.dir;
+              self.options.images.push({id, url, dir, mediaType, extension});
+            }
+            return $(elem).attr("src", `images/${id}.${extension}`);
           }
-          return $(elem).attr("src", `images/${id}.${extension}`);
         });
         content.data = $.xml();
         return content;


### PR DESCRIPTION
If an image has no `src` attribute, epub generation fails.

Epub generation fails, because it always assumes that `url` is a string, this is not the case.

Specifically, code breaks on [this line](https://github.com/cyrilis/epub-gen/compare/master...DanielApt:fix-no-src-attribute?expand=1#diff-2290943f47872064e53f430a293f3c8fL146). 

To prevent this from happening, this pull request checks if `url` exists before proceeding with setting ids and extensions.

This is a simplified version of https://github.com/cyrilis/epub-gen/pull/63, without any conflicts.